### PR TITLE
fix: run renderer production build in root build pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dev:renderer": "cd src/renderer && npm start",
     "dev:main": "electron . --remote-debugging-port=9222",
     "build": "npm run build:renderer && npm run build:main",
-    "build:renderer": "cd src/renderer && npm run start",
+    "build:renderer": "cd src/renderer && npm run build",
     "clean": "rimraf dist",
     "build:main": "electron-builder",
     "prebuild:win": "taskkill /f /im \"Casher Desktop.exe\" 2>nul & rmdir /s /q dist 2>nul & exit 0",


### PR DESCRIPTION
### Motivation
- The root `build` pipeline invoked the renderer dev server (`npm run start`) instead of performing a production build, which caused packaging failures when running `npm run build`.

### Description
- Change the root `build:renderer` script in `package.json` from `cd src/renderer && npm run start` to `cd src/renderer && npm run build` so the production renderer build is executed during packaging.

### Testing
- Ran `npm run build:renderer` from the repo root and observed it now dispatches to `cd src/renderer && npm run build`, but the build cannot complete in this environment because the `react-scripts` binary is missing and `cd src/renderer && npm install` fails with a TypeScript peer dependency conflict; automated build step therefore failed to finish.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b01828a708330a42945580509a05a)