### PR TITLE
build: enforce supported Node and x64 Windows packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
     "dev": "concurrently \"npm run dev:renderer\" \"npm run dev:main\" ",
     "dev:renderer": "cd src/renderer && npm start",
     "dev:main": "electron . --remote-debugging-port=9222",
-    "build": "npm run build:renderer && npm run build:main",
+    "build": "npm run check:node && npm run build:renderer && npm run build:main",
     "build:renderer": "cd src/renderer && npm run build",
     "clean": "rimraf dist",
-    "build:main": "electron-builder",
+    "build:main": "electron-builder --win --x64",
     "prebuild:win": "taskkill /f /im \"Casher Desktop.exe\" 2>nul & rmdir /s /q dist 2>nul & exit 0",
-    "build:win": "electron-builder --win --ia32 --x64=false",
+    "build:win": "electron-builder --win --x64",
     "build:win:smart": "node scripts/build-windows.cjs",
     "analyze:deps": "node scripts/analyze-dependencies.js",
     "debug:app": "node scripts/debug-app.js",
@@ -48,6 +48,7 @@
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "type-check": "tsc --noEmit",
     "prepare": "husky install",
+    "check:node": "node -e \"const [maj,min]=process.versions.node.split('.').map(Number); if(maj < 20 || (maj === 20 && min < 19)){ console.error('Node.js 20.19+ is required for Vite 7 builds. Current: ' + process.versions.node); process.exit(1);} \"",
     "postinstall": "cd src/renderer && npm install"
   },
   "dependencies": {
@@ -158,7 +159,7 @@
         {
           "target": "nsis",
           "arch": [
-            "ia32"
+            "x64"
           ]
         }
       ],
@@ -190,7 +191,7 @@
     ]
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.19.0",
     "npm": ">=8.0.0"
   }
 }


### PR DESCRIPTION
### Motivation
- Vite 7 requires Node.js 20.19+, and builds were producing confusing errors on unsupported Node versions, so fail early with a clear check. 
- Packaging for Windows hit native module rebuild failures (node-gyp / `usb`) when targeting ia32, so prefer x64-only packaging to avoid the ia32 rebuild path. 

### Description
- Added a `check:node` script (`node -e ...`) and updated the root `build` script to run `npm run check:node` before renderer and main builds. 
- Updated `build:main` and `build:win` to invoke `electron-builder --win --x64`. 
- Changed the Electron Builder `win.target.arch` entry to `x64` in the `build` config. 
- Bumped `engines.node` to `>=20.19.0` to make the Node runtime requirement explicit. 

### Testing
- Ran `npm run check:node`, which passed in this environment. 
- Ran `npm run build`, which now performs the node version check and then proceeds to the renderer step, but failed in this environment with `sh: 1: react-scripts: not found` (renderer dependency missing), so full packaging was not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b05669b948330a8d8c3dfe8a0f11b)